### PR TITLE
auth > dev       Text S3 파일 업로드 테스트용 API 추가. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
         "rxjs": "^7.2.0",
         "typeorm": "^0.3.12",
         "typeorm-extension": "^2.5.2",
-        "typeorm-naming-strategies": "^4.1.0"
+        "typeorm-naming-strategies": "^4.1.0",
+        "uuid": "^9.0.0"
       },
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
@@ -65,6 +66,7 @@
         "@types/passport-jwt": "^3.0.8",
         "@types/passport-local": "^1.0.35",
         "@types/supertest": "^2.0.11",
+        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^8.0.1",
@@ -3892,6 +3894,12 @@
       "dependencies": {
         "@types/superagent": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.7.12",
@@ -16864,6 +16872,12 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
+      "dev": true
     },
     "@types/validator": {
       "version": "13.7.12",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "rxjs": "^7.2.0",
     "typeorm": "^0.3.12",
     "typeorm-extension": "^2.5.2",
-    "typeorm-naming-strategies": "^4.1.0"
+    "typeorm-naming-strategies": "^4.1.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
@@ -91,6 +92,7 @@
     "@types/passport-jwt": "^3.0.8",
     "@types/passport-local": "^1.0.35",
     "@types/supertest": "^2.0.11",
+    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.1",

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -510,13 +510,45 @@ export class AuthController {
 
   // S3 - cloudFront 실험 api - 데이터 받아오기
   @Post('img-s3-test')
-  @UseInterceptors(FilesInterceptor('images'))
+  @UseInterceptors(FilesInterceptor('images', 4))
   async uploadFileTest(
     @UploadedFiles() images: Array<Express.Multer.File>,
     @Body() body: any,
   ) {
+    console.log('백엔드로 진입했어.');
     console.log(images);
     console.log(JSON.parse(body.jsonData).title);
+
+    await this.authService.uploadFileToS3(images, JSON.parse(body.jsonData));
+    return true;
+  }
+
+  // S3 - 썸네일 url 받아오기
+  @Get('img-s3-url')
+  async test222222() {
+    const thumbImgUrl = await this.authService.workshopThumbImg();
+    return thumbImgUrl;
+  }
+
+  // S3 - 리뷰 작성 시 동영상 받아오기.
+  @Post('video-s3-test')
+  @UseInterceptors(FileInterceptor('video'))
+  async uploadVideoFileTest(@UploadedFile() video: Express.Multer.File) {
+    console.log('동영상 보내기 api 메소드에 진입');
+    console.log(video);
+    await this.authService.uploadVideoToS3(video);
     return;
   }
+
+  // S3 - 리뷰 동영상 url 받아오기
+  @Get('video-s3-url')
+  async rwjioenw() {
+    const videoUrl = await this.authService.getVideoUrl();
+    return videoUrl;
+  }
+
+  // @Get('pleace')
+  // async ttttttt() {
+  //   await this.authService.userUptest();
+  // }
 }

--- a/views/test-minsoo/index.ejs
+++ b/views/test-minsoo/index.ejs
@@ -5,6 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+    <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
     <title>Document</title>
   </head>
   <style>
@@ -95,8 +96,78 @@
       <button onclick="submitContent()">전송하기</button>
     </div>
 
+    <div style="margin-top: 50px; margin-left: 50px">
+      <button onclick="getThumbImg()">썸네일 가져오기.</button>
+      <div>
+        !! 주의. 현재 썸네일 이름을 따로 DB에 저장하고 있지 않기 때문에 직접
+        버킷에서 이름을 복사해서 백엔드의 auth.service.ts 파일
+        workshopThumbImg() 함수의 thumbName 변수에 입력해 줘야 함.
+      </div>
+      <div style="max-width: 500px; width: 500px; margin-bottom: 200px">
+        <img id="thumb-show" style="max-width: 100%; display: block" />
+      </div>
+    </div>
+
+    <div
+      style="
+        margin-top: 50px;
+        margin-left: 50px;
+        margin-bottom: 200px;
+        border: 3px solid rgb(64, 64, 218);
+      "
+    >
+      <p>
+        동영상 파일 선택하기 및 S3 로 전송하기. 파일 선택 후 이미지 업로드 클릭
+      </p>
+      <input
+        type="file"
+        name="file"
+        id="video-file"
+        required="true"
+        accept="video/*"
+      />
+      <button onclick="submitVideo()">서버로 비디오 업로드</button>
+      <div id="video-wrap-div" style="margin-bottom: 100px; width: 500px">
+        <video
+          id="video-show-div"
+          style="display: none"
+          width="500px"
+          controls
+        ></video>
+      </div>
+    </div>
+
+    <div
+      style="
+        margin-top: 100px;
+        width: 700px;
+        height: 500px;
+        border: 3px solid black;
+      "
+    >
+      <p>
+        이미지와 마찬가지로 auth.service.ts 파일의 getVideoUrl 함수의 videoName
+        변수에 직접 입력해야 함. s3 버킷에 업로드 된 동영상 폴더의 이름을
+        가져와서.
+      </p>
+      <p style="font-size: 20px; font-weight: bold; color: red">
+        허나 문제 발생. 아마존 S3 의 주소 만으로는 동영상을 불러오는 데에
+        실패했음. 추후 Cloud Front 와 연결하면 가능할 것으로 보임. 일단 해당
+        기능은 보류. 현재 사용 불가.
+      </p>
+      <button onclick="getReviewVideo()">동영상 링크 가져오기.</button>
+      <video id="s3-video-show" style="display: none" width="500px" controls>
+        <source
+          src="https://workerbench.s3.ap-northeast-2.amazonaws.com/videos/review/1/d2049ab0-1b35-4868-9b50-b37b62906eaf.mov"
+          id="video-show-target"
+          type="application/x-mpegURL"
+        />
+      </video>
+    </div>
+
     <script>
       $(document).ready(function () {
+        // 이미지 미리보기
         const thumbImg = document.querySelector('#thumb-img-file');
         thumbImg.addEventListener('change', function (event) {
           let files = event.target.files;
@@ -140,6 +211,25 @@
           });
           reader.readAsDataURL(file);
         }
+
+        // 비디오 미리보기
+        const videoFile = document.querySelector('#video-file');
+        videoFile.addEventListener('change', (event) => {
+          let files = event.target.files;
+          if (files.length >= 1) {
+            const videoShow = document.querySelector('#video-show-div');
+            const videourl = URL.createObjectURL(files[0]);
+            videoShow.setAttribute('style', 'display:inline');
+            videoShow.setAttribute('src', videourl);
+            // videoShow.play();
+          }
+          if (!files.length) {
+            const videoWrap = document.querySelector('#video-wrap-div');
+            videoWrap.innerHTML = `<video id="video-show-div" style="display:none" width="500px" controls></video>`;
+            // const videoShow = document.querySelector('#video-show-div');
+            // videoShow.removeAttribute('src');
+          }
+        });
       });
 
       const submitContent = async () => {
@@ -175,22 +265,65 @@
           }
         }
 
-        $.ajax({
-          type: 'POST',
-          enctype: 'multipart/form-data',
-          url: '/api/auth/img-s3-test',
-          data: formData,
-          processData: false,
-          contentType: false,
-          cache: false,
-          success: function (response) {
-            console.log('okay~~~~');
-          },
-          error: function (request, status, error) {
-            console.log(
-              `${request.status} ${error} / ${request.responseJSON.msg}`,
-            );
-          },
+        // 첫 번째 인자가 api 주소, 두 번째 인자가 데이터, 세 번째 인자가 config
+        axios
+          .post('/api/auth/img-s3-test', formData, {
+            headers: {
+              'content-type': 'multipart/form-data',
+            },
+          })
+          .then((response) => {
+            console.log('무사히 통신 완료');
+            console.log(response);
+          })
+          .catch((err) => {
+            console.log('에러 발생. 400 번대 코드가 반환되면 catch로.');
+            console.log(err);
+          });
+      };
+
+      const getThumbImg = () => {
+        axios.get('/api/auth/img-s3-url').then((res) => {
+          console.log('썸네일 주소 가져오기 api 무사히 작동');
+          console.log(res.data.data);
+          document.querySelector('#thumb-show').src = res.data.data;
+        });
+      };
+
+      // 동영상 보내기
+      const submitVideo = () => {
+        // 비디오 파일
+        const check = document.querySelector('#video-file').files.length;
+        if (!check) {
+          return;
+        }
+        const video = document.querySelector('#video-file').files[0];
+
+        const formData = new FormData();
+        formData.append('video', video);
+
+        axios
+          .post('/api/auth/video-s3-test', formData, {
+            headers: {
+              'content-type': 'multipart/form-data',
+            },
+          })
+          .then((res) => {
+            console.log('정상 작동');
+            console.log(res);
+          })
+          .catch((err) => {
+            console.log('에러 발생');
+            console.log(err);
+          });
+      };
+
+      const getReviewVideo = () => {
+        axios.get('/api/auth/video-s3-url').then((res) => {
+          console.log('무사히 비디오 url 가져옴');
+          console.log(res.data.data);
+          // document.querySelector('#s3-video-show').src = res.data.data;
+          // document.querySelector('#video-show-target').src = res.data.data;
         });
       };
     </script>


### PR DESCRIPTION
## 개요
AWS S3 클라우드에 이미지 및 동영상을 업로드 해보는 테스트용 api 와 프론트가 포함되어 있음.



## 작업 사항
서버 실행 후 localhost:XXXX/api/auth/img-test 로 접속하면 테스트용 ejs 화면을 사용할 수 있습니다.
s3 세팅이 되어있다는 가정 하에 업로드는 잘 되지만 불러오기의 경우는 auth.service.ts 에 가셔서 직접 url 경로를 만들어 주셔야 합니다.
    (본래라면 DB에 삽입하였다가 꺼내서 사용하겠지만, 현재로서는 S3 파일 url 을 DB에 insert 하지 않고 있습니다.)

추가로, 동영상의 경우 하드 코딩으로 url 을 서버측에서 입력해 주더라도 현재 가져오지 못하는 상황입니다.
이는 CloundFront 를 추후에 도입한다면 해결될 것으로 보입니다.

!!!
기존에 DB에 작업하셨던 데이터들이 있으실 경우, typeorm.config.service.ts 와 dataSource.ts 파일의 
synchronize 가 false 인지 확인하신 후에 서버를 실행하실 것을 권장드립니다.
또한 redis 서버를 실행하신 후에 서버를 가동하시면 redis 관련 오류가 뜨지 않을 겁니다.


## 변경 로직 (optional)

.env 에 추가하셔야 하는 항목은 다음과 같습니다.


AWS_ACCESS_KEY = 
AWS_SECRET_KEY =
AWS_S3_REGION =
AWS_S3_BUCKET_NAME = 




## 주의 사항
- 내용을 적어주세요.

