### PR TITLE
워크샵 상세 이미지 + 리뷰 이미지 s3 / cloudFront 적용

### DIFF
--- a/public/main/js/main.js
+++ b/public/main/js/main.js
@@ -48,7 +48,7 @@ function getNewWorkshops() {
       workshops.forEach((element) => {
         let temp_html = `<div class="col">
         <div class="card h-100">
-            <a href="/workshop/detail?workshopId=${element.workshop_id}"><img
+            <a href="/workshops/detail?workshopId=${element.workshop_id}"><img
             src="https://tgzzmmgvheix1905536.cdn.ntruss.com/2017/10/e48b1391e6714813a1ff65dcd254488f"
             class="card-img-top"
             alt="..."/></a>

--- a/public/workshops/css/workshop-detail.css
+++ b/public/workshops/css/workshop-detail.css
@@ -1,8 +1,8 @@
 /* 웹 폰트 임포트 */
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap");
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap');
 
 body {
-  font-family: "Noto Sans KR", sans-serif;
+  font-family: 'Noto Sans KR', sans-serif;
 }
 
 img {
@@ -14,6 +14,7 @@ img {
 .workshop-thumb {
   object-fit: contain;
   margin-top: 20px;
+  margin-left: 200px;
 }
 
 .workshop-summary {

--- a/public/workshops/css/workshop-detail.css
+++ b/public/workshops/css/workshop-detail.css
@@ -11,6 +11,10 @@ img {
   border-radius: 20px;
 }
 
+.img-fluid {
+  display: inline-block;
+}
+
 .workshop-thumb {
   object-fit: contain;
   margin-top: 20px;

--- a/public/workshops/js/workshop-detail.js
+++ b/public/workshops/js/workshop-detail.js
@@ -1,6 +1,5 @@
 window.addEventListener('DOMContentLoaded', function () {
   getWorkshopDetail();
-  getThumbImg();
   getWorkshopReviews();
 });
 
@@ -58,6 +57,7 @@ function getWorkshopDetail() {
         </div>
       </div>`;
       $('#workshop-image-info').append(workshopInfo);
+      document.getElementById('workshop-thumb').src = workshop.workshop_thumb;
 
       // 찜하기 유저에 있으면 하트 칠하기
       if (wishCheck) {
@@ -78,15 +78,6 @@ function getWorkshopDetail() {
     })
     .catch((error) => {});
 }
-
-// 썸네일 가져오기
-const getThumbImg = () => {
-  axios.get('/api/auth/img-s3-url').then((res) => {
-    console.log('썸네일 주소 가져오기 api 무사히 작동');
-    console.log(res.data.data);
-    document.getElementById('workshop-thumb').src = res.data.data;
-  });
-};
 
 // 찜하기
 function addToWish() {

--- a/public/workshops/js/workshop-detail.js
+++ b/public/workshops/js/workshop-detail.js
@@ -122,8 +122,8 @@ function getWorkshopReviews() {
 
       reviews.forEach((element) => {
         let TempReviews = `<div class="card mb-3" style="max-width: 700px; margin-top: 50px"><div class="row g-0">
-          <div class="col-md-4">
-            <img class="img-fluid rounded-start" alt="..." id="review-img">
+          <div class="col-md-4 review-images">
+            <img class="img-fluid rounded-start" alt="..." id="review-img-1">
           </div>
           <div class="col-md-8">
             <div class="card-body">
@@ -135,7 +135,7 @@ function getWorkshopReviews() {
         </div>
         </div>`;
         $('#workshop-reviews').append(TempReviews);
-        document.getElementById('review-img').src = reviews[0].reviewImage;
+        document.getElementById('review-img-1').src = reviews[0].reviewImage;
       });
     })
     .catch((err) => {});

--- a/public/workshops/js/workshop-detail.js
+++ b/public/workshops/js/workshop-detail.js
@@ -13,13 +13,14 @@ function getWorkshopDetail() {
   axios
     .get(`/api/workshops/${workshopId}`)
     .then((res) => {
+      console.log(res.data.data);
       const workshop = res.data.data.workshop[0];
       const wishCheck = res.data.data.wish; // false or true
 
       let workshopInfo = `<div class="row">
         <div class="col">
           <div class="workshop-thumb">
-            <img src="/images/eraser-class-thumb.jpg" alt="..." />
+            <img id="workshop-thumb" alt="..." />
           </div>...
         </div>
   
@@ -83,7 +84,7 @@ const getThumbImg = () => {
   axios.get('/api/auth/img-s3-url').then((res) => {
     console.log('썸네일 주소 가져오기 api 무사히 작동');
     console.log(res.data.data);
-    document.querySelector('#workshop-thumb').src = res.data.data;
+    document.getElementById('workshop-thumb').src = res.data.data;
   });
 };
 
@@ -183,6 +184,7 @@ form.addEventListener('submit', function (e) {
   const company = document.getElementById('company').value;
   const name = document.getElementById('name').value;
   const email = document.getElementById('email').value;
+
   const phone_number = document.getElementById('phone_number').value;
   const wish_date = document.getElementById('wish_date').value;
   const category = $('input[name=category]:checked').val();
@@ -246,7 +248,7 @@ const getErrorCode = async (statusCode, errorMessage, callback) => {
   if (statusCode === 401) {
     const refreshRes = await requestAccessToken();
     if (!refreshRes) {
-      alert('현재 로그인이 되어있지 않습니다. 로그인 후 이용 가능합니다.');
+      alert('로그인 후 이용 가능합니다.');
       return;
     }
     callback();

--- a/public/workshops/js/workshop-detail.js
+++ b/public/workshops/js/workshop-detail.js
@@ -27,7 +27,7 @@ function getWorkshopDetail() {
         <div class="col">
           <div class="workshop-summary">
             <div class="workshop-title">${workshop.workshop_title}</div>
-            <div class="workshop-star">${workshop.averageStar}점</div>
+            <div class="workshop-star">평가 ${workshop.averageStar}점</div>
             <div class="workshop-category">${workshop.workshop_category}</div>
             <div class="workshop-location">
             활동 가능 지역 ${
@@ -41,8 +41,8 @@ function getWorkshopDetail() {
             <div class="workshop-total-time">총 시간 ${
               workshop.workshop_total_time
             }분</div>
-            <div class="workshop-genre">분야${workshop.genre}</div>
-            <div class="workshop-purpose">목적${workshop.purpose}</div>
+            <div class="workshop-genre">분야 ${workshop.genre}</div>
+            <div class="workshop-purpose">목적 ${workshop.purpose}</div>
             <div class="workshop-price">${workshop.workshop_price}원</div>
             <div>*1인 기준</div>
             <div class="order-wish-buttons">
@@ -118,11 +118,12 @@ function getWorkshopReviews() {
       const reviews = res.data.data;
 
       console.log(reviews);
+      console.log(reviews[0].reviewImage);
 
       reviews.forEach((element) => {
         let TempReviews = `<div class="card mb-3" style="max-width: 700px; margin-top: 50px"><div class="row g-0">
           <div class="col-md-4">
-            <img src="/images/eraser-class-review.jpg" class="img-fluid rounded-start" alt="...">
+            <img class="img-fluid rounded-start" alt="..." id="review-img">
           </div>
           <div class="col-md-8">
             <div class="card-body">
@@ -134,6 +135,7 @@ function getWorkshopReviews() {
         </div>
         </div>`;
         $('#workshop-reviews').append(TempReviews);
+        document.getElementById('review-img').src = reviews[0].reviewImage;
       });
     })
     .catch((err) => {});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -586,9 +586,9 @@ export class AuthService {
   async workshopThumbImg() {
     const workshop_id = 1;
     const region = this.configService.get('AWS_S3_REGION');
-    const thumbName = 'eraser-class-review.jpg';
+    const thumbName = 'images/workshop/1/eraser-class-thumb.jpg';
 
-    const thumbUrl = `https://workerbench-s3-bucket.s3.${region}.amazonaws.com/${thumbName}`;
+    const thumbUrl = `https://workerbench-mj.s3.${region}.amazonaws.com/${thumbName}`;
     return thumbUrl;
   }
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -586,10 +586,9 @@ export class AuthService {
   async workshopThumbImg() {
     const workshop_id = 1;
     const region = this.configService.get('AWS_S3_REGION');
-    const thumbName =
-      'images/workshop/1/e1564aae-939b-4e38-81d0-81d316d30266.jpeg';
+    const thumbName = 'eraser-class-review.jpg';
 
-    const thumbUrl = `https://workerbench.s3.${region}.amazonaws.com/${thumbName}`;
+    const thumbUrl = `https://workerbench-s3-bucket.s3.${region}.amazonaws.com/${thumbName}`;
     return thumbUrl;
   }
 

--- a/src/workshops/workshops.service.ts
+++ b/src/workshops/workshops.service.ts
@@ -238,7 +238,6 @@ export class WorkshopsService {
       const halfWish = wishArray.slice(0, wishHalfIndex); // 중복 값이 나오므로 배열 길이의 반만큼 잘라줘야 함
 
       // s3 + cloud front에서 이미지 가져오기
-      const region = this.configService.get('AWS_S3_REGION');
       const thumbName = workshop.workshop_thumb;
       const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
       const thumbUrl = `${cloundFrontUrl}/${thumbName}`;
@@ -303,7 +302,14 @@ export class WorkshopsService {
       const day = String(inputDate.getDate()).padStart(2, '0');
       const outputDate = `${year}-${month}-${day}`;
 
-      return { ...review, createdAt: outputDate };
+      // s3 + cloud front에서 이미지 가져오기
+      const reviewImageArr = reviews[0].ReviewImages[0];
+      const reviewImage = reviewImageArr.img_name;
+      const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+      const thumbUrl = `${cloundFrontUrl}/${reviewImage}`;
+      // ex) images/reviews/1/eraser-class-thumb.jpg 와 같은 파일명으로 저장되어 있음
+
+      return { ...review, createdAt: outputDate, reviewImage: thumbUrl };
     });
     return result;
   }

--- a/views/workshops/workshop-detail.ejs
+++ b/views/workshops/workshop-detail.ejs
@@ -56,10 +56,10 @@
                   <p>* '-' 없이 입력해주세요. (ex. 01012341234)</p>
                 </div>
                 <div class="mb-3">
-                  <input type="number" class="form-control" name="member_cnt" id="member_cnt" placeholder="인원">
+                  <input type="number" class="form-control" name="member_cnt" id="member_cnt" placeholder="인원" min=1>
                 </div>
                 <div class="mb-3">
-                  <input type="date" class="form-control" name="wish_date" id="wish_date">
+                  <input type="date" class="form-control" name="wish_date" id="wish_date" min="{{strTomorrow}}">
                   <p>* 희망하는 진행일을 선택해주세요.</p>
                 </div>
                 <div class="on-off-buttons">
@@ -67,8 +67,6 @@
                   <input type="radio" id="showAddress" name="category" value="offline"> 오프라인
                 </div>
                 <div class="mb-3" id="address">
-                  <!-- <input type="text" class="form-control" name="wish_location" id="wish_location" value="주소">
-                  <p>* 원하는 출강 위치의 주소를 정확히 입력해주세요.</p> -->
                   <input id="zip-code"  type="text" placeholder="우편번호 검색" readonly onclick="findAddr()"> <br>
                   <input id="input-address" type="text" placeholder="주소" value="주소" readonly> <br>
                   <input id="input_addr_detail" type="text" placeholder="상세 주소">
@@ -199,9 +197,23 @@
           })
       })
 
-      // 달력에 오늘 날짜 가져오기
-      document.getElementById("wish_date").valueAsDate = new Date();
+      // 달력에 내일 날짜 가져오기
+      let tomorrow = new Date();
+      tomorrow.setDate(new Date().getDate() + 1);
+      document.getElementById("wish_date").valueAsDate = tomorrow;
+
+      // 내일 날짜 문자열로 변경
+      const strTomorrow = tomorrow.toISOString().split('T')[0];
       
+      // user 로그인 여부 데이터 확인 후 false면 워크샵 문의 신청 막기
+      const user = '<%= user %>'
+      const modal = document.querySelector('#exampleModal')
+      modal.addEventListener('show.bs.modal', (e) => {
+        if(user === 'false')
+        alert('로그인 이후 이용 가능합니다!')
+        e.preventDefault()
+      })
+
   </script>
      <script src="/workshops/js/workshop-detail.js"></script>
     


### PR DESCRIPTION
## 개요
- 워크샵 상세 이미지 + 리뷰 이미지 s3 / cloudFront 적용

## 작업 사항
- 워크샵 신청 문의하기 클릭 시 로그인 여부에 따라 접근 허용/금지 로직 추가

- 워크샵 상세 이미지 s3 / cloudFront 적용
: 워크샵 상세 조회 api select 시 'workshop-thumb' 컬럼 추가
: db에 저장된 이미지 경로에 s3 버킷 내의 이미지 저장 경로와 cloudFront 도메인을 추가하여 프론트에서 렌더링

- 워크샵 리뷰 이미지 s3 / cloudFront 적용
: 기존 리뷰 조회 api는 review 테이블만 조회했으나 reviewImage 테이블과 join 추가
: 유저가 여러 개의 리뷰 이미지를 추가할 수 있어 배열 형태로 전달되나 현재는 첫 번째 이미지만 불러와서 렌더링 (추후 수정 가능)

## 변경 로직 (optional)
- 내용을 적어주세요.


## 주의 사항
- 인기 / 신규 워크샵 썸네일도 추후 적용 예정

