### PR TITLE
HotFix: teacher.module.ts 에 AuthModule 의존성 주입

### DIFF
--- a/src/teacher/teacher.module.ts
+++ b/src/teacher/teacher.module.ts
@@ -12,6 +12,7 @@ import { PurposeTag } from 'src/entities/purpose-tag';
 import { WorkShopInstanceDetail } from 'src/entities/workshop-instance.detail';
 import { CompanyApplication } from 'src/entities/company-application';
 import { WorkShopImage } from 'src/entities/workshop-image';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { WorkShopImage } from 'src/entities/workshop-image';
       CompanyApplication,
       WorkShopImage,
     ]),
+    AuthModule,
   ],
   controllers: [TeacherController, TeacherControllerRender],
   providers: [TeacherService],


### PR DESCRIPTION
## 개요
teacher 모듈 측 동적 페이지 랜더링 시 AuthModule 의존성 주입이 결여되어 유저의 정보를 찾을 수 없는 오류가 발생.


## 작업 사항
teacher.module.ts 에 AuthModule 의존성 주입


## 변경 로직 (optional)
- 내용을 적어주세요.


## 주의 사항
- 내용을 적어주세요.

