### PR TITLE
Auth 엔티티 수정 및 admin.service 측 이미지 클라우드 프론트 도메인 변경

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -59,7 +59,9 @@ export class AdminService {
       query.andWhere('user.email = :email', { email: `${options.email}` });
     }
 
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     const workshops = await query.getMany();
 
@@ -104,7 +106,9 @@ export class AdminService {
       query.andWhere('user.email = :email', { email: `${options.email}` });
     }
 
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     const workshops = await query.getMany();
 
@@ -150,7 +154,9 @@ export class AdminService {
       query.andWhere('user.email = :email', { email: `${options.email}` });
     }
 
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     const workshops = await query.getMany();
 
@@ -170,7 +176,9 @@ export class AdminService {
       .innerJoinAndSelect('workshop.GenreTag', 'genre')
       .getMany();
 
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     const result = workshops.map((workshop) => ({
       ...workshop,
@@ -188,7 +196,9 @@ export class AdminService {
       .innerJoinAndSelect('workshop.GenreTag', 'genre')
       .getMany();
 
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     const result = workshops.map((workshop) => ({
       ...workshop,
@@ -207,7 +217,9 @@ export class AdminService {
       .innerJoinAndSelect('workshop.GenreTag', 'genre')
       .getMany();
 
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     const result = workshops.map((workshop) => ({
       ...workshop,
@@ -247,7 +259,9 @@ export class AdminService {
 
     const workshopDetail = await query.getRawOne();
 
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     const result = {
       ...workshopDetail,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -37,9 +37,8 @@ import { Company } from 'src/entities/company';
 @Injectable()
 export class AuthService {
   private readonly redisClient: Redis;
-
   private readonly s3Client: S3Client;
-  public readonly S3_BUCKET_NAME: string;
+  public readonly AWS_S3_BUCKET_NAME_IMAGE_INPUT: string;
 
   constructor(
     @InjectRepository(User)
@@ -65,7 +64,9 @@ export class AuthService {
         secretAccessKey: this.configService.get('AWS_SECRET_KEY'),
       },
     });
-    this.S3_BUCKET_NAME = this.configService.get('AWS_S3_BUCKET_NAME');
+    this.AWS_S3_BUCKET_NAME_IMAGE_INPUT = this.configService.get(
+      'AWS_S3_BUCKET_NAME_IMAGE_INPUT',
+    );
   }
 
   // 유저 회원가입 시 유효성 검사
@@ -574,8 +575,8 @@ export class AuthService {
         // 첫 번째 image 일 경우 해당 이미지는 썸네일 이미지로 간주한다.
         if (index === 0) {
           const s3OptionForThumbImg = {
-            Bucket: this.configService.get('AWS_S3_BUCKET_NAME'), // S3의 버킷 이름.
-            Key: `images/workshops/2/original/${thumbImgName}`, // 폴더 구조와 파일 이름 (실제로는 폴더 구조는 아님. 그냥 사용자가 인지하기 쉽게 폴더 혹은 주소마냥 나타내는 논리적 구조.)
+            Bucket: this.configService.get('AWS_S3_BUCKET_NAME_IMAGE_INPUT'), // S3의 버킷 이름.
+            Key: `images/workshops/3/original/${thumbImgName}`, // 폴더 구조와 파일 이름 (실제로는 폴더 구조는 아님. 그냥 사용자가 인지하기 쉽게 폴더 혹은 주소마냥 나타내는 논리적 구조.)
             Body: image.buffer, // 업로드 하고자 하는 파일.
           };
           await this.s3Client.send(new PutObjectCommand(s3OptionForThumbImg)); // 실제로 S3 클라우드로 파일을 전송 및 업로드 하는 코드.
@@ -587,8 +588,8 @@ export class AuthService {
           const subImgName = uuid() + subImgType;
 
           const s3OptionForSubImg = {
-            Bucket: this.configService.get('AWS_S3_BUCKET_NAME'),
-            Key: `images/workshops/2/original/${subImgName}`,
+            Bucket: this.configService.get('AWS_S3_BUCKET_NAME_IMAGE_INPUT'),
+            Key: `images/workshops/3/original/${subImgName}`,
             Body: image.buffer,
           };
           await this.s3Client.send(new PutObjectCommand(s3OptionForSubImg));
@@ -603,9 +604,11 @@ export class AuthService {
   async workshopThumbImg() {
     const workshop_id = 1;
     const region = this.configService.get('AWS_S3_REGION');
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
     const thumbName =
-      'images/workshop/1/0dd9de79-2c49-4bb9-a462-c73b9f363e7b.jpeg';
+      'images/workshops/3/800/46c6217a-cb8e-4795-b185-8dcc5e2e61cb.jpeg';
 
     // const thumbUrl = `https://workerbench.s3.${region}.amazonaws.com/${thumbName}`;
     const thumbUrl = `${cloundFrontUrl}${thumbName}`;
@@ -626,8 +629,8 @@ export class AuthService {
 
     // s3 에 입력할 옵션
     const s3OptionForReviewVideo = {
-      Bucket: this.S3_BUCKET_NAME,
-      Key: `videos/review/1/${videoName}`,
+      Bucket: this.configService.get('AWS_S3_BUCKET_NAME_VIDEO_INPUT'),
+      Key: `videos/workshops/3/original/${videoName}`,
       Body: video.buffer,
     };
 
@@ -641,9 +644,13 @@ export class AuthService {
   async getVideoUrl() {
     const review_id = 1;
     const region = this.configService.get('AWS_S3_REGION');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_VIDEO',
+    );
     const videoName =
-      'videos/review/1/d2049ab0-1b35-4868-9b50-b37b62906eaf.mov';
-    const videoUrl = `https://workerbench.s3.${region}.amazonaws.com/${videoName}`;
+      'videos/review/1/original/38d56d07-2326-4806-8ac6-289a2054f7b2.mov';
+    // https://d3uycps0xwbcx9.cloudfront.net/videos/review/1/original/38d56d07-2326-4806-8ac6-289a2054f7b2.mov
+    const videoUrl = `${cloundFrontUrl}${videoName}`;
     return videoUrl;
   }
 

--- a/src/entities/company-application.ts
+++ b/src/entities/company-application.ts
@@ -20,6 +20,14 @@ export class CompanyApplication {
   @Column('int', { name: 'company_id', nullable: true })
   company_id: number | null;
 
+  @Column('varchar', {
+    name: 'status',
+    length: 50,
+    nullable: true,
+    default: 'request',
+  })
+  status: 'request' | 'rejected';
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/entities/order.ts
+++ b/src/entities/order.ts
@@ -29,6 +29,17 @@ export class Order {
   @Column('varchar', { name: 'imp_uid', length: 100, nullable: false })
   imp_uid: string;
 
+  @IsString({ message: '주문 고유번호를 정확히 입력해 주세요' })
+  @IsNotEmpty()
+  @ApiProperty({
+    example: '2389289-20230313',
+    description:
+      '외부 API 를 통해 결제를 하였을 경우 얻을 수 있는 주문 고유 번호',
+    required: true,
+  })
+  @Column('varchar', { name: 'merchant_uid', length: 200, nullable: false })
+  merchant_uid: string;
+
   @IsNumber()
   @IsNotEmpty({ message: '결제된 금액을 입력해 주세요' })
   @ApiProperty({

--- a/src/entities/review.ts
+++ b/src/entities/review.ts
@@ -40,6 +40,14 @@ export class Review {
   @Column('decimal', { name: 'star', nullable: false })
   star: number;
 
+  @Column('varchar', {
+    name: 'video',
+    length: 200,
+    nullable: true,
+    default: null,
+  })
+  video: string | null;
+
   @Column('int', { name: 'user_id', nullable: true })
   user_id: number | null;
 

--- a/src/entities/workshop-instance.detail.ts
+++ b/src/entities/workshop-instance.detail.ts
@@ -87,7 +87,7 @@ export class WorkShopInstanceDetail {
     nullable: false,
     default: 'request',
   })
-  status: 'request' | 'non_payment' | 'waiting_lecture' | 'complete';
+  status: 'request' | 'non_payment' | 'waiting_lecture' | 'complete' | 'refund';
 
   @IsString()
   @IsNotEmpty({ message: '워크샵을 희망하시는 이유를 적어주세요' })

--- a/src/entities/workshop.ts
+++ b/src/entities/workshop.ts
@@ -124,6 +124,14 @@ export class WorkShop {
   @Column('varchar', { name: 'location', length: 100, nullable: true })
   location: string | null;
 
+  @Column('varchar', {
+    name: 'video',
+    length: 200,
+    nullable: true,
+    default: null,
+  })
+  video: string | null;
+
   @Column('int', { name: 'user_id', nullable: true })
   user_id: number | null;
 

--- a/src/teacher/teacher.service.ts
+++ b/src/teacher/teacher.service.ts
@@ -28,7 +28,8 @@ import { identity } from 'rxjs';
 @Injectable()
 export class TeacherService {
   private readonly s3Client: S3Client;
-  public readonly S3_BUCKET_NAME: string;
+  public readonly AWS_S3_BUCKET_NAME_IMAGE_INPUT: string;
+
   constructor(
     @InjectRepository(Teacher) private teacherRepository: Repository<Teacher>,
     @InjectRepository(User) private userRepository: Repository<User>,
@@ -52,7 +53,9 @@ export class TeacherService {
         secretAccessKey: this.configService.get('AWS_SECRET_KEY'),
       },
     });
-    this.S3_BUCKET_NAME = this.configService.get('AWS_S3_BUCKET_NAME');
+    this.AWS_S3_BUCKET_NAME_IMAGE_INPUT = this.configService.get(
+      'AWS_S3_BUCKET_NAME_IMAGE_INPUT',
+    );
   }
   // 강사 등록 api
 
@@ -327,7 +330,7 @@ export class TeacherService {
         // 첫 번째 image 일 경우 해당 이미지는 썸네일 이미지로 간주한다.
         if (index === 0) {
           const s3OptionForThumbImg = {
-            Bucket: this.configService.get('AWS_S3_BUCKET_NAME'), // S3의 버킷 이름.
+            Bucket: this.AWS_S3_BUCKET_NAME_IMAGE_INPUT, // S3의 버킷 이름.
             Key: `images/workshops/${workshop.identifiers[0].id}/original/${thumbImgName}`, // 폴더 구조와 파일 이름 (실제로는 폴더 구조는 아님. 그냥 사용자가 인지하기 쉽게 폴더 혹은 주소마냥 나타내는 논리적 구조.)
             Body: image.buffer, // 업로드 하고자 하는 파일.
           };
@@ -344,7 +347,7 @@ export class TeacherService {
           });
           // 서브이미지 파일 경로
           const s3OptionForSubImg = {
-            Bucket: this.configService.get('AWS_S3_BUCKET_NAME'),
+            Bucket: this.AWS_S3_BUCKET_NAME_IMAGE_INPUT,
             Key: `images/workshops/${workshop.identifiers[0].id}/original/${subImgName}`,
             Body: image.buffer,
           };

--- a/src/workshops/workshops.service.ts
+++ b/src/workshops/workshops.service.ts
@@ -54,7 +54,9 @@ export class WorkshopsService {
       .getRawMany();
 
     // s3 + cloud front에서 이미지 가져오기
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     // , 기준으로 나누고 purpose_name 값 중복 제거
     const result = workshops.map((workshop) => ({
@@ -96,7 +98,9 @@ export class WorkshopsService {
       .getRawMany();
 
     // s3 + cloud front에서 이미지 가져오기
-    const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+    const cloundFrontUrl = this.configService.get(
+      'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+    );
 
     // , 기준으로 나누고 purpose_name 값 중복 제거
     const result = queryBuilder.map((workshop) => ({
@@ -181,7 +185,7 @@ export class WorkshopsService {
       ...workshop,
       purposeTag_name: workshop.purposeTag_name.split(','),
       thumb: `${this.configService.get(
-        'AWS_CLOUD_FRONT_DOMAIN',
+        'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
       )}images/workshops/${workshop.workshop_id}/800/${
         workshop.workshop_thumb
       }`,
@@ -253,7 +257,9 @@ export class WorkshopsService {
 
       // s3 + cloud front에서 이미지 가져오기
       const thumbName = workshop.workshop_thumb;
-      const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+      const cloundFrontUrl = this.configService.get(
+        'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+      );
       const thumbUrl = `${cloundFrontUrl}images/workshops/${workshop.workshop_id}/800/${thumbName}`;
       // ex) images/workshop/1/eraser-class-thumb.jpg 와 같은 파일명으로 저장되어 있음
 
@@ -319,7 +325,9 @@ export class WorkshopsService {
       // s3 + cloud front에서 이미지 가져오기
       const reviewImageArr = reviews[0].ReviewImages[0];
       const reviewImage = reviewImageArr.img_name;
-      const cloundFrontUrl = this.configService.get('AWS_CLOUD_FRONT_DOMAIN');
+      const cloundFrontUrl = this.configService.get(
+        'AWS_CLOUD_FRONT_DOMAIN_IMAGE',
+      );
       const thumbUrl = `${cloundFrontUrl}/${reviewImage}`;
       // ex) images/reviews/1/eraser-class-thumb.jpg 와 같은 파일명으로 저장되어 있음
 

--- a/views/test-minsoo/index.ejs
+++ b/views/test-minsoo/index.ejs
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+    <link href="https://vjs.zencdn.net/8.0.4/video-js.css" rel="stylesheet" />
+    <script src="https://vjs.zencdn.net/7.10.2/video.min.js"></script>
     <title>Document</title>
   </head>
   <style>


### PR DESCRIPTION
## 개요
 엔티티 수정 및 admin.service 측 이미지 클라우드 프론트 도메인 변경

## 작업 사항
결제 확인 후 merchant_uid 기록을 위해 order 테이블에 칼럼 추가.
환불 시 workshop_instance_detail 의 status 를 refund 로 교체. order 는 soft delete
workshop 과 review 테이블에 video 칼럼 추가
company_application 테이블에 현재 신청 상태를 알기 위해 status 칼럼 추가.

admin.service 에서 사용되는 이미지 가져오기 용 클라우드 프론트의 환경변수 이름을 수정.


## 변경 로직 (optional)
- 내용을 적어주세요.


## 주의 사항
- 내용을 적어주세요.

