### PR TITLE
Auth Fix: company 엔티티 company_type 설명 수정

### DIFF
--- a/src/entities/company.ts
+++ b/src/entities/company.ts
@@ -23,7 +23,7 @@ export class Company {
   @IsNotEmpty({ message: '업체 종류를 선택해 주세요' })
   @ApiProperty({
     example: 1,
-    description: '업체 종류. 1=business, 2=freelancer',
+    description: '업체 종류. 0=business, 1=freelancer',
     required: true,
   })
   @Column('int', {


### PR DESCRIPTION
## 개요



## 작업 사항
// company.ts

@IsNumber()
  @IsNotEmpty({ message: '업체 종류를 선택해 주세요' })
  @ApiProperty({
    example: 1,
    description: '업체 종류. 0=business, 1=freelancer',
    required: true,
  })
  @Column('int', {
    name: 'company_type',
    nullable: false,
  })
  company_type: number;

===> description 설명란에 기존의 1=business, 2=freelancer를 위와 같이 변경


## 변경 로직 (optional)
- 내용을 적어주세요.


## 주의 사항
- 내용을 적어주세요.

