### PR TITLE
Auth 유저 테스트 배포 전 수정사항 수정

### DIFF
--- a/dataSource.ts
+++ b/dataSource.ts
@@ -48,7 +48,7 @@ const dataSource = new DataSource({
   migrations: [__dirname + '/src/migrations/*.ts'],
   charset: 'utf8mb4_general_ci',
   synchronize: false,
-  logging: true,
+  // logging: true,
 });
 
 export default dataSource;

--- a/public/main/js/main.js
+++ b/public/main/js/main.js
@@ -67,9 +67,10 @@ function getNewWorkshops() {
           element.workshop_max_member
         }명</p>
           <p class="card-text">시간 &nbsp;${element.workshop_total_time}분</p>
-          <p class="card-text">#${element.genre_tag_name} #${
-          element.purpose_name[0]
-        } #${element.purpose_name[1]}</p>
+          <p class="card-text">#${element.genre_tag_name}
+            #${element.purpose_name[0]}
+            ${element.purpose_name[1] ? `#${element.purpose_name[1]}` : ''}
+          </p>
           </div>
         </div>
       </div>`;

--- a/public/mypage/js/wish-list.js
+++ b/public/mypage/js/wish-list.js
@@ -21,7 +21,6 @@ function getWishList() {
     .get('/api/mypage/workshops/wishlist')
     .then((res) => {
       const workshops = res.data.data;
-      console.log('workshops', workshops);
 
       workshops.forEach((element) => {
         let tempHtml = `<div class="col" id="wish-card-${element.workshop_id}">

--- a/public/mypage/js/workshops.js
+++ b/public/mypage/js/workshops.js
@@ -23,7 +23,6 @@ function getSoonWorkshops() {
     .get('/api/mypage/workshops/soon')
     .then((res) => {
       const workshops = res.data.data;
-      console.log('workshops', workshops);
 
       workshops.forEach((element) => {
         let tempHtml = `<div class="col">
@@ -115,8 +114,6 @@ function showIncompleteModal(workshopDetailId) {
     .get(`/api/mypage/workshops/soon/${workshopDetailId}`)
     .then((res) => {
       const workshop = res.data.data[0];
-      console.log(workshop);
-
       const modal = document.getElementById('modal');
       modal.innerHTML = `
             <div class="modal-content">
@@ -212,8 +209,6 @@ function putWorkshopOrderInfo(workshopDetailId) {
   axios
     .post(`/api/mypage/workshops/orderInfo`, { workshopDetailId })
     .then((res) => {
-      console.log(res);
-      console.log(workshopDetailId, '결제 입력창 열기');
       const workshop = res.data.data[0];
 
       const modal = document.getElementById('modal');
@@ -330,8 +325,6 @@ function open_iamport() {
     },
     function (rsp) {
       if (rsp.success) {
-        console.log(rsp);
-
         axios
           .patch('/api/mypage/workshops/order', {
             workshopInstance_id,
@@ -340,7 +333,6 @@ function open_iamport() {
             merchant_uid: rsp.merchant_uid,
           })
           .then((response) => {
-            console.log(response);
             alert('결제가 완료되었습니다.');
             location.href = '/mypage/workshops';
           })
@@ -349,7 +341,6 @@ function open_iamport() {
             alert(error.message / error.response.data.message);
           });
       } else {
-        console.log(rsp);
         alert('결제가 실패했습니다.');
       }
     },
@@ -361,8 +352,6 @@ function putWorkshopRefundInfo(workshopDetailId) {
   axios
     .post(`/api/mypage/workshops/refundInfo`, { workshopDetailId })
     .then((res) => {
-      console.log(res);
-      console.log(workshopDetailId, '환불 입력창 열기');
       const workshop = res.data.data[0];
 
       const modal = document.getElementById('refund-modal');
@@ -448,7 +437,6 @@ function cancel_pay() {
       reason: reason, // 환불사유
     },
     success: function (response) {
-      console.log(response);
       alert('결제 취소가 완료되었습니다.');
       location.reload();
     },
@@ -464,7 +452,6 @@ function getCompleteWorkshops() {
     .get('/api/mypage/workshops/complete')
     .then((res) => {
       const workshops = res.data.data;
-      console.log('workshops', workshops);
 
       workshops.forEach((element) => {
         let tempHtml = `<div class="col">
@@ -493,7 +480,6 @@ function showCompleteModal(workshopDetailId) {
     .get(`/api/mypage/workshops/complete/${workshopDetailId}`)
     .then((res) => {
       const workshop = res.data.data[0];
-      console.log(workshop);
 
       const modal = document.getElementById('modal');
       modal.innerHTML = `
@@ -701,9 +687,6 @@ const submitReview = async (workshop_id, workshopInstanceDetail_id) => {
   const starValue = parseInt($('input[name="reviewStar"]:checked').val());
   const reviewContent = $('#reviewContents').val();
 
-  console.log('검사용~~');
-  console.log(workshop_id, workshopInstanceDetail_id);
-
   if (!starValue) {
     alert('별점을 입력해주세요!');
     return;
@@ -776,7 +759,6 @@ function getRefundWorkshops() {
     .get('/api/mypage/workshops/refund')
     .then((res) => {
       const workshops = res.data.data;
-      console.log('workshops', workshops);
 
       workshops.forEach((element) => {
         let tempHtml = `<div class="col">
@@ -823,7 +805,6 @@ function showRefundModal(workshopDetailId) {
     .get(`/api/mypage/workshops/refund/${workshopDetailId}`)
     .then((res) => {
       const workshop = res.data.data[0];
-      console.log(res);
 
       const modal = document.getElementById('modal');
       modal.innerHTML = `

--- a/public/teacher/js/teacher-manage-complete.js
+++ b/public/teacher/js/teacher-manage-complete.js
@@ -6,7 +6,6 @@ document.addEventListener('DOMContentLoaded', () => {
     data: {},
   })
     .then((response) => {
-      console.log(response);
       const data = response.data.complete_instance_list;
       for (let i = 0; i < data.length; i++) {
         const workshop_thumb = data[i].workshopThumbUrl;
@@ -55,7 +54,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     })
     .catch((response) => {
-      console.log(response);
       const { data } = response.response;
       alert(data.error);
     });

--- a/public/teacher/js/teacher-manage-incomplete.js
+++ b/public/teacher/js/teacher-manage-incomplete.js
@@ -8,7 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
     data: {},
   })
     .then((response) => {
-      console.log(response);
       const data = response.data.non_complete_instance_list;
       for (let i = 0; i < data.length; i++) {
         const workshop_thumb = data[i].workshop_thumb;
@@ -51,7 +50,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         `;
             break;
         }
-        console.log(buttonHtml);
+
         let tempHtml = ``;
         tempHtml += `
                     <div class="teacher-manage-div" >

--- a/public/teacher/js/teacher-workshop-information.js
+++ b/public/teacher/js/teacher-workshop-information.js
@@ -22,6 +22,16 @@ document.addEventListener('DOMContentLoaded', () => {
         bank_name,
         account,
         saving_name;
+
+      if (data.MyCompany) {
+        company_type = data.MyCompany.company_type;
+        company_name = data.MyCompany.company_name;
+        business_number = data.MyCompany.business_number;
+        rrn_front = data.MyCompany.rrn_front;
+        bank_name = data.MyCompany.bank_name;
+        account = data.MyCompany.account;
+        saving_name = data.MyCompany.saving_name;
+      }
       if (data.company) {
         company_type = data.company.company_type;
         company_name = data.company.company_name;
@@ -53,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 </div>
       `;
       } else if (data.MyCompany && company_type === 0) {
+        console.log('여기가 걸리긴 해야 함ㅁ!');
         companyHtml += `
                               <div class="teacher-workshop-li-div">
                                   <li class="teacher-workshop-li">업체종류</li>

--- a/public/teacher/js/teacher-workshop-information.js
+++ b/public/teacher/js/teacher-workshop-information.js
@@ -198,7 +198,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // 등록된 업체에 등록 신청
 function applyCompany(id) {
-  console.log(id);
   axios({
     method: 'post',
     url: `/api/teacher/company/apply/${id}`,
@@ -210,7 +209,6 @@ function applyCompany(id) {
       location.reload();
     })
     .catch((response) => {
-      console.log(response);
       const { data } = response.response;
       alert(data.error);
     });
@@ -223,9 +221,7 @@ function acceptListCompany() {
     data: {},
   })
     .then((response) => {
-      console.log(response);
       const data = response.data;
-      console.log(data);
       let html = '';
       for (let i = 0; i < data.length; i++) {
         const name = data[i].name;

--- a/public/teacher/js/teacher-workshop.js
+++ b/public/teacher/js/teacher-workshop.js
@@ -69,7 +69,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     })
     .catch((response) => {
-      console.log(response);
       const { data } = response.response;
       alert(data.error);
     });

--- a/public/teacher/js/workshop-register.js
+++ b/public/teacher/js/workshop-register.js
@@ -78,10 +78,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const location = document.getElementById('location').value;
     const purpose_value1 = parseInt(purpose_tag1);
     const purpose_value2 = parseInt(purpose_tag2);
+
     if (!purpose_value1 && !purpose_value2) {
       alert('목적태그 최소 한개는 등록해주세요');
       return;
     }
+
+    if (purpose_value1 === purpose_value2) {
+      alert('중복된 목적을 선택하셨습니다.');
+      return;
+    }
+
     const purposeTagIds = [purpose_value1, purpose_value2];
     if (
       category === '' ||

--- a/public/workshops/js/workshop-detail.js
+++ b/public/workshops/js/workshop-detail.js
@@ -12,7 +12,6 @@ function getWorkshopDetail() {
   axios
     .get(`/api/workshops/${workshopId}`)
     .then((res) => {
-      console.log(res.data.data);
       const workshop = res.data.data.workshop[0];
       const wishCheck = res.data.data.wish; // false or true
       let workshopInfo = `<div class="row">
@@ -172,7 +171,6 @@ function addToWish() {
   axios
     .post(`/api/workshops/${workshopId}/wish`) // user_id 임시로 하드코딩
     .then((res) => {
-      console.log(res);
       alert(res.data.data.message);
       if (res.data.data.type === 'add') {
         document.querySelector('.wish').textContent = '♥';
@@ -199,7 +197,6 @@ function getWorkshopReviews() {
   axios
     .get(`/api/workshops/${workshopId}/reviews`) // user_id 임시로 하드코딩
     .then((res) => {
-      console.log(res);
       const reviews = res.data.data;
 
       reviews.forEach((element, index) => {
@@ -241,8 +238,6 @@ const form = document.getElementById('form');
 function findAddr() {
   new daum.Postcode({
     oncomplete: function (data) {
-      console.log(data);
-
       // 팝업에서 검색결과 항목을 클릭했을때 실행할 코드를 작성하는 부분.
       // 도로명 주소의 노출 규칙에 따라 주소를 표시한다.
       // 내려오는 변수가 값이 없는 경우엔 공백('')값을 가지므로, 이를 참고하여 분기 한다.

--- a/public/workshops/js/workshop-search.js
+++ b/public/workshops/js/workshop-search.js
@@ -12,9 +12,6 @@ function getAllWorkshops() {
     .get(url)
     .then((res) => {
       const workshops = res.data.data;
-      console.log(res.data.data);
-      console.log(workshops.length);
-      console.log(url, params);
 
       // 검색 결과 건수 표시
       document.querySelector(
@@ -85,9 +82,6 @@ function searchWorkshops() {
       .get(url, { params })
       .then((res) => {
         const workshops = res.data.data;
-        console.log(res.data.data);
-        console.log(workshops.length);
-        console.log(url, params);
 
         // 검색 결과 건수 표시
         document.querySelector(
@@ -138,9 +132,6 @@ function searchWorkshops() {
       .get(url, { params })
       .then((res) => {
         const workshops = res.data.data;
-        console.log(res.data.data);
-        console.log(workshops.length);
-        console.log(url, params);
 
         $('.workshop-result-list').empty();
         if (workshops.length === 0) {
@@ -196,9 +187,6 @@ function searchWorkshops() {
       .get(url, { params })
       .then((res) => {
         const workshops = res.data.data;
-        console.log(res.data.data);
-        console.log(workshops.length);
-        console.log(url, params);
 
         $('.workshop-result-list').empty();
         if (workshops.length === 0) {
@@ -254,9 +242,6 @@ function searchWorkshops() {
       .get(url, { params })
       .then((res) => {
         const workshops = res.data.data;
-        console.log(res.data.data);
-        console.log(workshops.length);
-        console.log(url, params);
 
         $('.workshop-result-list').empty();
         if (workshops.length === 0) {
@@ -311,9 +296,6 @@ function searchWorkshops() {
       .get(url, { params })
       .then((res) => {
         const workshops = res.data.data;
-        console.log(res.data.data);
-        console.log(workshops.length);
-        console.log(url, params);
 
         $('.workshop-result-list').empty();
         if (workshops.length === 0) {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -466,95 +466,46 @@ export class AuthController {
 
   /* -------------------------------- 테스트용 API -------------------------------- */
 
-  // 유저 테스트
-  @Get('test')
-  @UseGuards(JwtUserAuthGuard)
-  async test22(@CurrentUser() user: CurrentUserDto) {
-    console.log('---- 테스트 잘 작동함!');
-    console.log(user);
-    return;
-  }
+  // // 유저 테스트
+  // @Get('test')
+  // @UseGuards(JwtUserAuthGuard)
+  // async test22(@CurrentUser() user: CurrentUserDto) {
+  //   return;
+  // }
 
-  // 강사 테스트
-  @Get('test2')
-  @UseGuards(JwtTeacherAuthGuard)
-  async test233(@CurrentUser() user: CurrentUserDto) {
-    console.log('---- 테스트 잘 작동함!');
-    console.log(user.id);
-    return;
-  }
+  // // 강사 테스트
+  // @Get('test2')
+  // @UseGuards(JwtTeacherAuthGuard)
+  // async test233(@CurrentUser() user: CurrentUserDto) {
+  //   return;
+  // }
 
-  // 부 관리자 테스트
-  @Get('admintest')
-  @UseGuards(JwtNormalAdminAuthGuard)
-  async test66(@CurrentUser() admin: CurrentAdminDto) {
-    console.log('부 관리자 테스트!');
-    console.log(admin);
-  }
+  // // 부 관리자 테스트
+  // @Get('admintest')
+  // @UseGuards(JwtNormalAdminAuthGuard)
+  // async test66(@CurrentUser() admin: CurrentAdminDto) {}
 
-  // 최고 관리자 테스트
-  @Get('superadmintest')
-  @UseGuards(JwtSuperAdminAuthGuard)
-  async test77(@CurrentUser() admin: CurrentAdminDto) {
-    console.log('최고 관리자 테스트!');
-    console.log(admin);
-  }
+  // // 최고 관리자 테스트
+  // @Get('superadmintest')
+  // @UseGuards(JwtSuperAdminAuthGuard)
+  // async test77(@CurrentUser() admin: CurrentAdminDto) {}
 
   /* -------------------------------- S3 업로드 테스트용  API -------------------------------- */
 
-  // S3 - cloudFront 실험 api - ejs 랜더링
-  @Get('img-test')
-  @Render('test-minsoo/index')
-  test333() {
-    return;
-  }
-
   // S3 - cloudFront 실험 api - 데이터 받아오기
-  @Post('img-s3-test')
-  @UseInterceptors(
-    FilesInterceptor('images', 4, { limits: { fileSize: 5 * 1024 * 1024 } }),
-  ) // 두번째 인자는 'images' 라는 이름에 담길 수 있는 총 파일 갯수. 즉 4면 4개 까지만 보낼 수 있어.
-  async uploadFileTest(
-    @UploadedFiles() images: Array<Express.Multer.File>,
-    @Body() body: any,
-  ) {
-    // 사진 용량이 예를 들어 127KB 라면, 사이즈가 127000 바이트로 나옴. 참고로 limit 의 fileSize 는 단위가 바이트
-    // FilesInterceptor('images', 4, { limits: { fileSize: 100000 } }), 이렇게면, images 이름으로 파일이 총 4개 들어올 수 있으며, 사이즈는 100,000 바이트, 즉 100KB 까지만 허락한다.
-    // FilesInterceptor('images', 4, { limits: { fileSize: 5 * 1024 * 1024 } }), 위랑 같은데 이 경우 각 파일당 용량 제한이 5MB
-    console.log('백엔드로 진입했어.');
-    console.log(images);
-    console.log(JSON.parse(body.jsonData).title);
+  // @Post('img-s3-test')
+  // @UseInterceptors(
+  //   FilesInterceptor('images', 4, { limits: { fileSize: 5 * 1024 * 1024 } }),
+  // ) // 두번째 인자는 'images' 라는 이름에 담길 수 있는 총 파일 갯수. 즉 4면 4개 까지만 보낼 수 있어.
+  // async uploadFileTest(
+  //   @UploadedFiles() images: Array<Express.Multer.File>,
+  //   @Body() body: any,
+  // ) {
+  //   // 사진 용량이 예를 들어 127KB 라면, 사이즈가 127000 바이트로 나옴. 참고로 limit 의 fileSize 는 단위가 바이트
+  //   // FilesInterceptor('images', 4, { limits: { fileSize: 100000 } }), 이렇게면, images 이름으로 파일이 총 4개 들어올 수 있으며, 사이즈는 100,000 바이트, 즉 100KB 까지만 허락한다.
+  //   // FilesInterceptor('images', 4, { limits: { fileSize: 5 * 1024 * 1024 } }), 위랑 같은데 이 경우 각 파일당 용량 제한이 5MB
 
-    await this.authService.uploadFileToS3(images, JSON.parse(body.jsonData));
-    return true;
-  }
-
-  // S3 - 썸네일 url 받아오기
-  @Get('img-s3-url')
-  async test222222() {
-    const thumbImgUrl = await this.authService.workshopThumbImg();
-    return thumbImgUrl;
-  }
-
-  // S3 - 리뷰 작성 시 동영상 받아오기.
-  @Post('video-s3-test')
-  @UseInterceptors(FileInterceptor('video'))
-  async uploadVideoFileTest(@UploadedFile() video: Express.Multer.File) {
-    console.log('동영상 보내기 api 메소드에 진입');
-    console.log(video);
-    await this.authService.uploadVideoToS3(video);
-    return;
-  }
-
-  // S3 - 리뷰 동영상 url 받아오기
-  @Get('video-s3-url')
-  async rwjioenw() {
-    const videoUrl = await this.authService.getVideoUrl();
-    return videoUrl;
-  }
-
-  // @Get('pleace')
-  // async ttttttt() {
-  //   await this.authService.userUptest();
+  //   await this.authService.uploadFileToS3(images, JSON.parse(body.jsonData));
+  //   return true;
   // }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -109,7 +109,6 @@ export class AuthService {
 
   // 유저 회원가입 시 이메일 중복 검사
   async checkingAccount(email: string) {
-    console.log('111111');
     const check_email = await this.userRepository.findOne({ where: { email } });
     if (check_email) {
       throw new BadRequestException('이미 존재하는 이메일 입니다.');
@@ -128,7 +127,6 @@ export class AuthService {
 
   // 유저 회원가입 시 이메일 인증코드 발송
   async sendingEmailAuthCode(email: string) {
-    console.log('2222222222');
     const auth_num = randomBytes(3).toString('hex');
     await this.redisClient.setex(emailAuthCodeRedisKey(email), 300, auth_num); // redis set
 
@@ -143,8 +141,6 @@ export class AuthService {
         console.log(result);
       })
       .catch((error) => {
-        console.log('33333333333333333');
-        console.log(error);
         throw new ConflictException();
       });
     return;

--- a/src/config/typeorm.config.service.ts
+++ b/src/config/typeorm.config.service.ts
@@ -50,7 +50,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
         WorkShop,
       ],
       synchronize: false,
-      logging: true, // sql 문 띄워줌
+      // logging: true, // sql 문 띄워줌
       keepConnectionAlive: true, // 이거 안 켜두면 서버 재시작할 때 DB 연결을 끊어버려.
       charset: 'utf8mb4', // 나중에 이모티콘도 추가할려고
     };

--- a/src/entities/company.ts
+++ b/src/entities/company.ts
@@ -51,7 +51,7 @@ export class Company {
     description: '사업자 법인번호. `-` 없이 입력해 주세요',
     required: false,
   })
-  @Column('int', { name: 'business_number', nullable: true })
+  @Column('bigint', { name: 'business_number', nullable: true })
   business_number: number | null;
 
   @IsNumber()
@@ -94,7 +94,7 @@ export class Company {
     description: '계좌 번호. `-` 없이 입력',
     required: true,
   })
-  @Column('int', { name: 'account', nullable: false })
+  @Column('bigint', { name: 'account', nullable: false })
   account: number;
 
   @IsString({ message: '예금주 성함을 정확히 입력해 주세요' })

--- a/src/mypage/mypage.controller.ts
+++ b/src/mypage/mypage.controller.ts
@@ -163,7 +163,6 @@ export class MypageController {
     @Body() refundInfo: RefundDto,
     @CurrentUser() user: CurrentUserDto,
   ) {
-    console.log('-----', refundInfo);
     const check_result = await this.mypageService.refundWorkshopPayment(
       user.id,
       refundInfo,

--- a/src/mypage/mypage.service.ts
+++ b/src/mypage/mypage.service.ts
@@ -306,7 +306,6 @@ export class MypageService {
         },
       });
       const { access_token } = getToken.data.response; // 인증 토큰
-      console.log('accesstoken 발급', access_token);
 
       // imp_uid로 아임포트 서버에서 결제 정보 조회
       const getPaymentData = await axios({
@@ -315,7 +314,6 @@ export class MypageService {
         headers: { Authorization: access_token }, // 인증 토큰 Authorization header에 추가
       });
       const paymentData = getPaymentData.data.response; // 조회한 결제 정보
-      console.log('paymentData 조회', paymentData);
 
       // 결제금액의 위변조 여부를 검증.
       // 클라이언트에서 입력받은 merchant_uid 와 토큰으로 가져온 merchant_uid 이 다르다면 에러
@@ -339,11 +337,7 @@ export class MypageService {
 
       // 결제 검증하기
       const { amount, status, pay_method } = paymentData;
-      console.log('api 로 가져온 결제 내역');
-      console.log(paymentData);
       if (amount === amountToBePaid) {
-        console.log('문제 없으니 db에 오더 추가');
-        console.log(amount, typeof amount);
         // DB에 결제 내역 저장
         const insertOrder = await this.orderRepository.insert({
           user_id,
@@ -365,7 +359,7 @@ export class MypageService {
 
         switch (status) {
           case 'ready':
-            console.log('가상 계좌가 발급되었음.');
+            // console.log('가상 계좌가 발급되었음.');
             return true;
           case 'paid':
             return true;
@@ -394,10 +388,6 @@ export class MypageService {
       .innerJoinAndSelect('workshopDetail.OrderInfo', 'order')
       .where('workshopDetail.id = :id', { id: workshopInstanceId })
       .getRawMany();
-
-    console.log('11111111');
-    console.log(workshopInstanceId);
-    console.log(workshopDetail);
 
     if (!workshopDetail) {
       throw new NotFoundException('수강 문의 기록이 존재하지 않습니다.');
@@ -443,8 +433,6 @@ export class MypageService {
       });
       const { access_token } = getToken.data.response; // 인증 토큰
 
-      console.log('0------', access_token);
-
       /* 포트원 REST API로 결제환불 요청 */
       const getCancelData = await axios({
         url: 'https://api.iamport.kr/payments/cancel',
@@ -460,7 +448,6 @@ export class MypageService {
         },
       });
 
-      console.log('cancelData', getCancelData);
       const { response } = getCancelData.data;
       // const { merchant_uid } = response; // 환불 결과에서 주문정보 추출
 

--- a/src/mypage/mypage.service.ts
+++ b/src/mypage/mypage.service.ts
@@ -344,6 +344,7 @@ export class MypageService {
           imp_uid: paymentData.imp_uid,
           merchant_uid,
           workshop_id,
+          workshop_instance_detail_id: Number(workshopInstance_id),
           amount,
           pay_method,
           status,

--- a/src/teacher/teacher.service.ts
+++ b/src/teacher/teacher.service.ts
@@ -180,9 +180,13 @@ export class TeacherService {
         ]);
       const results = await query.getMany();
       const teacher = results[0]; // results가 배열 형태이므로 배열을 없앤 값을 teacher에 넣어줬다.
-      let company = teacher.MyCompany;
-      if (!company && userIdInfo.affiliation_company_id > 0) {
-        // 만약에 teacher.MyCompany가 없거나 userIdInfo.affiliation_company_id가 0보다 클경우 찾는다.
+      let company = { ...teacher.MyCompany };
+
+      if (
+        Object.keys(company).length === 0 &&
+        userIdInfo.affiliation_company_id > 0
+      ) {
+        // 만약에 teacher.MyCompany가 없거나 userIdInfo.affiliation_company_id가 0보다 클경우 찾는다. 강사가 업체에 소속되어 있는 경우.
         company = await this.companyRepository.findOne({
           where: { id: userIdInfo.affiliation_company_id },
           select: ['company_name', 'saving_name', 'company_type'],
@@ -190,6 +194,7 @@ export class TeacherService {
       } else {
         company = null; // company가 있으면 위에 쿼리빌더로 나온 Mycompany랑 company값이 나와 총 두번 보여지므로 하나는 안보여지게 했다.
       }
+
       return {
         ...teacher,
         company,
@@ -500,7 +505,7 @@ export class TeacherService {
         genre_id,
         total_time,
         price,
-        status: 'request',
+        status: 'approval', // 유저 테스트 종료 시 'request' 로 변환해야 함.
         location,
         desc,
         user_id: userId,

--- a/src/workshops/workshops.service.ts
+++ b/src/workshops/workshops.service.ts
@@ -396,6 +396,7 @@ export class WorkshopsService {
       phone_number,
       member_cnt,
       wish_date,
+      status: 'non_payment', // 유저 테스트 종료 시 해당 입력 항목을 삭제. (default = request)
       category,
       purpose,
       wish_location,

--- a/views/test-minsoo/index.ejs
+++ b/views/test-minsoo/index.ejs
@@ -275,19 +275,15 @@
             },
           })
           .then((response) => {
-            console.log('무사히 통신 완료');
             console.log(response);
           })
           .catch((err) => {
-            console.log('에러 발생. 400 번대 코드가 반환되면 catch로.');
             console.log(err);
           });
       };
 
       const getThumbImg = () => {
         axios.get('/api/auth/img-s3-url').then((res) => {
-          console.log('썸네일 주소 가져오기 api 무사히 작동');
-          console.log(res.data.data);
           document.querySelector('#thumb-show').src = res.data.data;
         });
       };
@@ -311,11 +307,9 @@
             },
           })
           .then((res) => {
-            console.log('정상 작동');
             console.log(res);
           })
           .catch((err) => {
-            console.log('에러 발생');
             console.log(err);
             if (err.status === 404) {
               axios
@@ -333,8 +327,8 @@
 
       const getReviewVideo = () => {
         axios.get('/api/auth/video-s3-url').then((res) => {
-          console.log('무사히 비디오 url 가져옴');
-          console.log(res.data.data);
+          // console.log('무사히 비디오 url 가져옴');
+          // console.log(res.data.data);
           // document.querySelector('#s3-video-show').src = res.data.data;
           // document.querySelector('#video-show-target').src = res.data.data;
         });


### PR DESCRIPTION
## 개요
유저 테스트 배포 전 수정사항 수정
- 수정 사항 -
1. 워크샵 등록 시 목적 태그 등록 버그
2. 강사 업체 및 정보 버그
3. 환불 에러
4. 메인화면 태그 에러


## 작업 사항
1.
워크샵 등록 시 목적 태그 등록
			=> 동일한 목적 태그 선택해도 insert 가 됨
			=> 동일한 목적 태그를 선택하지 못하도록 프론트에서 막음 (해결)

2.
강사 관리 페이지 - 강사 및 업체 정보
			=> 강사가 스스로 업체를 등록했을 시 업체 정보에 보이지 않음
			=> 백엔드 및 프론트에서 ‘강사 및 업체 정보’ 가져올 시 if 문으로
			Mycompany, company 의 값에 대한 조건문을 추가함 (해결)

3.
환불 
			=> internet error
			=> 결제 시 workshop_instance_detail_id 입력이 되지 않던 것을
			입력되도록 insert 구문에 추가 (해결)


4.
메인화면 태그 문제
			=> 메인 화면에서 워크샵 카드 가져올 시,
			목적 태그가 1개만 설정되어 있다면 2번째 태그가 undefined 라고 띄움.
			=> js 파일에서 html 태그 추가 시, 템플릿 리터럴 문법 안에서
			논리 삼항식을 사용하여 두 번째 태그가 존재할 때에만 html 를 추가
			(해결)


## 변경 로직 (optional)
- 내용을 적어주세요.


## 주의 사항
< 테스트 배포 종료 시 변경이 필요한 로직 >
1.
테스트 동안은 강사가 워크샵 등록 시 바로 approval 로 하도록.

2.
유저가 워크샵 수강 문의 신청 시 바로 non_payment 로 되도록.

3.
Mypage 에서 imp 가맹점 고유번호를 자신의 포트원 설정에 맞게 변경!
			=> 안했을 시 결제 처리에 에러 사항 발생.


