### PR TITLE
메인페이지 신규 워크샵 보여주기 개수 4-> 8개 증가

### DIFF
--- a/src/workshops/workshops.service.ts
+++ b/src/workshops/workshops.service.ts
@@ -96,7 +96,7 @@ export class WorkshopsService {
       .andWhere('workshop.status = :status', { status: 'approval' })
       .orderBy('workshop.updatedAt', 'DESC') // 업데이트 최신순으로 정렬
       .groupBy('workshop.id')
-      .limit(4)
+      .limit(8)
       .getRawMany();
 
     // s3 + cloud front에서 이미지 가져오기


### PR DESCRIPTION
## 개요
Fix: 메인페이지 신규 워크샵 보여주기 개수 4-> 8개 증가


## 작업 사항
- 내용을 적어주세요. (최대한 구체적으로)


## 변경 로직 (optional)
- 내용을 적어주세요.


## 주의 사항
- 내용을 적어주세요.

