### PR TITLE
Auth 메인 페이지 인기 워크샵 오류 수정 및 강사 페이지 HTML 수정

### DIFF
--- a/dataSource.ts
+++ b/dataSource.ts
@@ -47,7 +47,7 @@ const dataSource = new DataSource({
   ],
   migrations: [__dirname + '/src/migrations/*.ts'],
   charset: 'utf8mb4_general_ci',
-  synchronize: true,
+  synchronize: false,
   // logging: true,
 });
 

--- a/public/main/js/main.js
+++ b/public/main/js/main.js
@@ -29,10 +29,10 @@ function getBestWorkshops() {
           element.workshop_max_member
         }명</p>
             <p class="card-text">시간 &nbsp;${element.workshop_total_time}분</p>
-            <p class="card-text">#${element.genre_tag_name} #${
-          element.purpose_name[0]
-        } #${element.purpose_name[1]}</p>
-          </div>
+            <p class="card-text">#${element.genre_tag_name}
+            #${element.purpose_name[0]}
+            ${element.purpose_name[1] ? `#${element.purpose_name[1]}` : ''}
+          </p>
         </div>
       </div>`;
         $('#best-workshop-list').append(tempHtml);

--- a/src/config/typeorm.config.service.ts
+++ b/src/config/typeorm.config.service.ts
@@ -49,7 +49,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
         WorkShopPurpose,
         WorkShop,
       ],
-      synchronize: true,
+      synchronize: false,
       // logging: true, // sql 문 띄워줌
       keepConnectionAlive: true, // 이거 안 켜두면 서버 재시작할 때 DB 연결을 끊어버려.
       charset: 'utf8mb4', // 나중에 이모티콘도 추가할려고


### PR DESCRIPTION
## 개요
메인 페이지 인기 워크샵 목적 태그 오류 수정, 강사 관리 페이지의 워크샵 날짜 표기 수정

## 작업 사항
메인 페이지에 나오는 인기 워크샵 중 목적 태그가 1개일 경우 나머지 한 자리를 undefined 로 출력하는 버그 발견. 이를 수정.
강사 전용 페이지에서 워크샵 정보 확인 시 등록 날짜가 실제 날짜보다 1개월 빠른 시간대로 표기된 것을 확인. 이를 수정.


## 변경 로직 (optional)
- 내용을 적어주세요.


## 주의 사항
- 내용을 적어주세요.

